### PR TITLE
Added tailwind.config.js to Dockerfile copy commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ RUN yarn install
 FROM node:18-alpine AS css-builder
 WORKDIR /src
 COPY --from=node-dependencies /dependencies/node_modules ./node_modules
-COPY ["Warp.WebApp/package.json", "Warp.WebApp/postcss.config.js", "./"]
+COPY ["Warp.WebApp/package.json", "Warp.WebApp/postcss.config.js", "Warp.WebApp/tailwind.config.js", "./"]
+# Copy all content that Tailwind needs to scan
+COPY ["Warp.WebApp/Pages", "./Pages"]
+COPY ["Warp.WebApp/Views", "./Views"]
+COPY ["Warp.WebApp/wwwroot/js", "./wwwroot/js"]
+COPY ["Warp.WebApp/Components", "./Components"]
 COPY ["Warp.WebApp/Styles", "./Styles"]
 RUN yarn build
 

--- a/Warp.WebApp/postcss.config.js
+++ b/Warp.WebApp/postcss.config.js
@@ -1,5 +1,4 @@
 export default {
-    
     plugins: {
       "@tailwindcss/postcss": {},
       autoprefixer: {},

--- a/Warp.WebApp/tailwind.config.js
+++ b/Warp.WebApp/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     content: [
         "./**/*.{html,cshtml,js,jsx,ts,tsx}",
     ],


### PR DESCRIPTION
- Added `tailwind.config.js` to Dockerfile copy commands.
- Included additional directories for Tailwind scanning: `Pages`, `Views`, `wwwroot/js`, and `Components`.
- Changed `postcss.config.js` and `tailwind.config.js` to use ES module syntax.